### PR TITLE
Fix bug about split_model = False

### DIFF
--- a/object_detection.py
+++ b/object_detection.py
@@ -281,8 +281,9 @@ def detection(detection_graph, category_index, score, expand):
                 fps.update()
 
     # End everything
-    gpu_worker.stop()
-    cpu_worker.stop()
+    if split_model:
+      gpu_worker.stop()
+      cpu_worker.stop()
     fps.stop()
     video_stream.stop()
     cv2.destroyAllWindows()


### PR DESCRIPTION
when split_model = False, there maybe an error like
"
Traceback (most recent call last):
  File "object_detection.py", line 314, in <module>
    main()
  File "object_detection.py", line 310, in main
    detection(graph, category, score, expand)
  File "object_detection.py", line 297, in detection
    gpu_worker.stop()
UnboundLocalError: local variable 'gpu_worker' referenced before assignment
"